### PR TITLE
Fix build error

### DIFF
--- a/examples/threads/CMakeLists.txt
+++ b/examples/threads/CMakeLists.txt
@@ -47,6 +47,6 @@ foreach(example_program ${example_programs})
 
   # add dependencies to pseudo-target
   add_hpx_pseudo_dependencies(
-    examples.threads.${example_program} ${example_program}_exe
+    examples.threads.${example_program} ${example_program}
   )
 endforeach()

--- a/examples/threads/pthread_compatibility_header.c
+++ b/examples/threads/pthread_compatibility_header.c
@@ -3,7 +3,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpxc/pthread_compatibility.h>
 #include <limits.h>
 
 #include <stdio.h>
@@ -12,6 +11,10 @@
 #include <sys/time.h>
 #include <unistd.h>
 #endif
+
+// this include has to come afte the system include
+// to avoid conflicting types
+#include <hpxc/pthread_compatibility.h>
 
 pthread_attr_t attr;
 

--- a/examples/threads/pthread_test.c
+++ b/examples/threads/pthread_test.c
@@ -22,7 +22,7 @@ int main(int argc, char** argv)
     pthread_t test;
     pthread_create(&test, NULL, print_hello, NULL);
     int* result = NULL;
-    pthread_join(test, &result);
+    pthread_join(test, (void**) &result);
     printf("Returned result: %d\n", *result);
     return 0;
 }

--- a/hpxc/config.h
+++ b/hpxc/config.h
@@ -9,7 +9,7 @@
 #include <hpxc/config/export_definitions.h>
 
 #if !defined(_MSC_VER)
-#define HPXC_HAVE_RW_LOCK
+//#define HPXC_HAVE_RW_LOCK
 #endif
 
 #if !defined(HPXC_SMALL_STACK_SIZE)

--- a/hpxc/pthread_compatibility.h
+++ b/hpxc/pthread_compatibility.h
@@ -83,4 +83,5 @@
 #define phtread_cleanup_push hpxc_thread_cleanup_push
 #define phtread_cleanup_pop hpxc_thread_cleanup_pop
 
+#undef PTHREAD_STACK_MIN 
 #define PTHREAD_STACK_MIN HPXC_SMALL_STACK_SIZE


### PR DESCRIPTION
This PR fixed the following error, and has to be merged after https://github.com/STEllAR-GROUP/hpxc/pull/9 is merged

```
[ 93%] Linking CXX executable ../../bin/pthread_test
In file included from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/pthread_compatibility.h:13:19: error: conflicting types for ‘hpxc_thread_t’; have ‘long unsigned int’
   13 | #define pthread_t hpxc_thread_t
      |                   ^~~~~~~~~~~~~
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:33:3: note: previous declaration of ‘hpxc_thread_t’ with type ‘hpxc_thread_t’
   33 | } hpxc_thread_t;
      |   ^~~~~~~~~~~~~
In file included from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/pthread_compatibility.h:17:23: error: conflicting types for ‘hpxc_key_t’; have ‘unsigned int’
   17 | #define pthread_key_t hpxc_key_t
      |                       ^~~~~~~~~~
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:53:3: note: previous declaration of ‘hpxc_key_t’ with type ‘hpxc_key_t’
   53 | } hpxc_key_t;
      |   ^~~~~~~~~~
In file included from /usr/include/sys/types.h:227,
                 from /usr/include/stdlib.h:394,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:10:
/usr/include/bits/pthreadtypes.h:57:1: error: ‘hpxc_thread_attr_t’ defined as wrong kind of tag
   57 | {
      | ^
In file included from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/pthread_compatibility.h:16:24: error: conflicting types for ‘hpxc_thread_attr_t’; have ‘union hpxc_thread_attr_t’
   16 | #define pthread_attr_t hpxc_thread_attr_t
      |                        ^~~~~~~~~~~~~~~~~~
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:48:3: note: previous declaration of ‘hpxc_thread_attr_t’ with type ‘hpxc_thread_attr_t’
   48 | } hpxc_thread_attr_t;
      |   ^~~~~~~~~~~~~~~~~~
In file included from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/pthread_compatibility.h:14:25: error: conflicting types for ‘hpxc_mutex_t’; have ‘union <anonymous>’
   14 | #define pthread_mutex_t hpxc_mutex_t
      |                         ^~~~~~~~~~~~
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:38:3: note: previous declaration of ‘hpxc_mutex_t’ with type ‘hpxc_mutex_t’
   38 | } hpxc_mutex_t;
      |   ^~~~~~~~~~~~
In file included from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/pthread_compatibility.h:15:24: error: conflicting types for ‘hpxc_cond_t’; have ‘union <anonymous>’
   15 | #define pthread_cond_t hpxc_cond_t
      |                        ^~~~~~~~~~~
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:43:3: note: previous declaration of ‘hpxc_cond_t’ with type ‘hpxc_cond_t’
   43 | } hpxc_cond_t;
      |   ^~~~~~~~~~~
In file included from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/pthread_compatibility.h:19:30: error: conflicting types for ‘hpxc_rwlockattr_t’; have ‘union <anonymous>’
   19 | #define pthread_rwlockattr_t hpxc_rwlockattr_t
      |                              ^~~~~~~~~~~~~~~~~
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:68:3: note: previous declaration of ‘hpxc_rwlockattr_t’ with type ‘hpxc_rwlockattr_t’
   68 | } hpxc_rwlockattr_t;
      |   ^~~~~~~~~~~~~~~~~
In file included from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/pthread_compatibility.h:18:28: error: conflicting type qualifiers for ‘hpxc_spinlock_t’
   18 | #define pthread_spinlock_t hpxc_spinlock_t
      |                            ^~~~~~~~~~~~~~~
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:70:22: note: previous declaration of ‘hpxc_spinlock_t’ with type ‘hpxc_spinlock_t’ {aka ‘hpxc_mutex_t’}
   70 | typedef hpxc_mutex_t hpxc_spinlock_t;
      |                      ^~~~~~~~~~~~~~~
[ 93%] Built target cancel
[ 93%] Built target pthread_test
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c: In function ‘fib’:
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:30:20: warning: passing argument 1 of ‘hpxc_thread_create’ from incompatible pointer type [-Wincompatible-pointer-types]
   30 |     pthread_create(&t1, &attr, fib, (void*) (n - 1));
      |                    ^~~
      |                    |
      |                    hpxc_thread_t * {aka long unsigned int *}
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:74:55: note: expected ‘hpxc_thread_t *’ but argument is of type ‘hpxc_thread_t *’ {aka ‘long unsigned int *’}
   74 | HPXC_API_EXPORT int hpxc_thread_create(hpxc_thread_t* thread_id,
      |                                        ~~~~~~~~~~~~~~~^~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:30:25: warning: passing argument 2 of ‘hpxc_thread_create’ from incompatible pointer type [-Wincompatible-pointer-types]
   30 |     pthread_create(&t1, &attr, fib, (void*) (n - 1));
      |                         ^~~~~
      |                         |
      |                         hpxc_thread_attr_t *
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:75:31: note: expected ‘const hpxc_thread_attr_t *’ but argument is of type ‘hpxc_thread_attr_t *’
   75 |     hpxc_thread_attr_t const* attributes, void* (*thread_function)(void*),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:31:20: warning: passing argument 1 of ‘hpxc_thread_create’ from incompatible pointer type [-Wincompatible-pointer-types]
   31 |     pthread_create(&t2, &attr, fib, (void*) (n - 2));
      |                    ^~~
      |                    |
      |                    hpxc_thread_t * {aka long unsigned int *}
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:74:55: note: expected ‘hpxc_thread_t *’ but argument is of type ‘hpxc_thread_t *’ {aka ‘long unsigned int *’}
   74 | HPXC_API_EXPORT int hpxc_thread_create(hpxc_thread_t* thread_id,
      |                                        ~~~~~~~~~~~~~~~^~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:31:25: warning: passing argument 2 of ‘hpxc_thread_create’ from incompatible pointer type [-Wincompatible-pointer-types]
   31 |     pthread_create(&t2, &attr, fib, (void*) (n - 2));
      |                         ^~~~~
      |                         |
      |                         hpxc_thread_attr_t *
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:75:31: note: expected ‘const hpxc_thread_attr_t *’ but argument is of type ‘hpxc_thread_attr_t *’
   75 |     hpxc_thread_attr_t const* attributes, void* (*thread_function)(void*),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:33:18: error: incompatible type for argument 1 of ‘hpxc_thread_join’
   33 |     pthread_join(t1, &r1);
      |                  ^~
      |                  |
      |                  hpxc_thread_t {aka long unsigned int}
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:80:52: note: expected ‘hpxc_thread_t’ but argument is of type ‘hpxc_thread_t’ {aka ‘long unsigned int’}
   80 | HPXC_API_EXPORT int hpxc_thread_join(hpxc_thread_t thread_id, void** value_ptr);
      |                                      ~~~~~~~~~~~~~~^~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:34:18: error: incompatible type for argument 1 of ‘hpxc_thread_join’
   34 |     pthread_join(t2, &r2);
      |                  ^~
      |                  |
      |                  hpxc_thread_t {aka long unsigned int}
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:80:52: note: expected ‘hpxc_thread_t’ but argument is of type ‘hpxc_thread_t’ {aka ‘long unsigned int’}
   80 | HPXC_API_EXPORT int hpxc_thread_join(hpxc_thread_t thread_id, void** value_ptr);
      |                                      ~~~~~~~~~~~~~~^~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c: In function ‘fib_helper’:
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:45:20: warning: passing argument 1 of ‘hpxc_thread_create’ from incompatible pointer type [-Wincompatible-pointer-types]
   45 |     pthread_create(&thread, &attr, fib, (void*) (n));
      |                    ^~~~~~~
      |                    |
      |                    hpxc_thread_t * {aka long unsigned int *}
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:74:55: note: expected ‘hpxc_thread_t *’ but argument is of type ‘hpxc_thread_t *’ {aka ‘long unsigned int *’}
   74 | HPXC_API_EXPORT int hpxc_thread_create(hpxc_thread_t* thread_id,
      |                                        ~~~~~~~~~~~~~~~^~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:45:29: warning: passing argument 2 of ‘hpxc_thread_create’ from incompatible pointer type [-Wincompatible-pointer-types]
   45 |     pthread_create(&thread, &attr, fib, (void*) (n));
      |                             ^~~~~
      |                             |
      |                             hpxc_thread_attr_t *
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:75:31: note: expected ‘const hpxc_thread_attr_t *’ but argument is of type ‘hpxc_thread_attr_t *’
   75 |     hpxc_thread_attr_t const* attributes, void* (*thread_function)(void*),
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:46:18: error: incompatible type for argument 1 of ‘hpxc_thread_join’
   46 |     pthread_join(thread, &result);
      |                  ^~~~~~
      |                  |
      |                  hpxc_thread_t {aka long unsigned int}
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:80:52: note: expected ‘hpxc_thread_t’ but argument is of type ‘hpxc_thread_t’ {aka ‘long unsigned int’}
   80 | HPXC_API_EXPORT int hpxc_thread_join(hpxc_thread_t thread_id, void** value_ptr);
      |                                      ~~~~~~~~~~~~~~^~~~~~~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c: In function ‘hpxc_user_main’:
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:59:23: warning: passing argument 1 of ‘hpxc_thread_attr_init’ from incompatible pointer type [-Wincompatible-pointer-types]
   59 |     pthread_attr_init(&attr);
      |                       ^~~~~
      |                       |
      |                       hpxc_thread_attr_t *
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:90:63: note: expected ‘hpxc_thread_attr_t *’ but argument is of type ‘hpxc_thread_attr_t *’
   90 | HPXC_API_EXPORT int hpxc_thread_attr_init(hpxc_thread_attr_t* attr);
      |                                           ~~~~~~~~~~~~~~~~~~~~^~~~
/home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:60:31: warning: passing argument 1 of ‘hpxc_thread_attr_setstacksize’ from incompatible pointer type [-Wincompatible-pointer-types]
   60 |     pthread_attr_setstacksize(&attr, PTHREAD_STACK_MIN);
      |                               ^~~~~
      |                               |
      |                               hpxc_thread_attr_t *
In file included from /home/weile/src/hpxc/hpxc/threads.h:10,
                 from /home/weile/src/hpxc/hpxc/pthread_compatibility.h:11,
                 from /home/weile/src/hpxc/examples/threads/pthread_compatibility_header.c:6:
/home/weile/src/hpxc/hpxc/threads/thread.h:115:25: note: expected ‘hpxc_thread_attr_t *’ but argument is of type ‘hpxc_thread_attr_t *’
  115 |     hpxc_thread_attr_t* attr, size_t stacksize);
      |     ~~~~~~~~~~~~~~~~~~~~^~~~
make[2]: *** [examples/threads/CMakeFiles/pthread_compatibility_header.dir/build.make:76: examples/threads/CMakeFiles/pthread_compatibility_header.dir/pthread_compatibility_header.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:884: examples/threads/CMakeFiles/pthread_compatibility_header.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 96%] Linking CXX executable ../../bin/fib_naive
[ 96%] Built target fib_naive
make: *** [Makefile:136: all] Error 2
```