### PR TITLE
Fixing hpxc_thread_exit not to rely on exceptions

### DIFF
--- a/examples/threads/cancel.c
+++ b/examples/threads/cancel.c
@@ -11,6 +11,9 @@
 #include <unistd.h>
 #endif
 
+int hpxc_thread_testcancel();
+int hpxc_thread_cancel(hpxc_thread_t);
+
 void* until_I_die(void* p)
 {
     while (1)
@@ -30,7 +33,7 @@ int main(int argc, char* argv[])
     hpxc_thread_join(once, &retval);
 
     if (retval != HPXC_CANCELED)
-        printf("Something went wront!\n");
+        printf("Something went wrong!\n");
     else
         printf("Cancelation was successful.\n");
 

--- a/examples/threads/counter.c
+++ b/examples/threads/counter.c
@@ -39,6 +39,9 @@ int main(int argc, char* argv[])
     {
         hpxc_thread_join(threads[i], 0);
     }
+
+    hpxc_mutex_destroy(&mut);
+
     printf("finished: counter=%d\n", counter);
 
     return 0;

--- a/examples/threads/counter2.c
+++ b/examples/threads/counter2.c
@@ -49,8 +49,6 @@ int main(int argc, char* argv[])
     double t1, t2;
     hpxc_thread_t fin;
 
-    mut = HPXC_MUTEX_INITIALIZER;
-
     timerclear(&tv);
     gettimeofday(&tv, &tz);
     t1 = tv.tv_sec + 1.0e-6 * tv.tv_usec;
@@ -66,6 +64,9 @@ int main(int argc, char* argv[])
 
     hpxc_thread_create(&fin, NULL, finish, NULL);
     hpxc_thread_join(fin, NULL);
+
+    hpxc_cond_destroy(&cond);
+    hpxc_mutex_destroy(&mut);
 
     timerclear(&tv);
     gettimeofday(&tv, &tz);

--- a/examples/threads/counter3.c
+++ b/examples/threads/counter3.c
@@ -61,12 +61,15 @@ int main(int argc, char* argv[])
     for (i = 0; i < NTHREADS; i++)
     {
         hpxc_thread_t th;
-        hpxc_thread_create(&th, NULL, incr, NULL);
+        hpxc_thread_create(&th, &attr, incr, NULL);
     }
     hpxc_thread_attr_destroy(&attr);
 
     hpxc_thread_create(&fin, NULL, finish, NULL);
     hpxc_thread_join(fin, NULL);
+
+    hpxc_cond_destroy(&cond);
+    hpxc_mutex_destroy(&mut);
 
     timerclear(&tv);
     gettimeofday(&tv, &tz);

--- a/examples/threads/counter4.c
+++ b/examples/threads/counter4.c
@@ -65,12 +65,15 @@ int main(int argc, char* argv[])
     for (i = 0; i < NTHREADS; i++)
     {
         hpxc_thread_t th;
-        hpxc_thread_create(&th, NULL, incr, NULL);
+        hpxc_thread_create(&th, &attr, incr, NULL);
     }
     hpxc_thread_attr_destroy(&attr);
 
     hpxc_thread_create(&fin, NULL, finish, NULL);
     hpxc_thread_join(fin, NULL);
+
+    hpxc_cond_destroy(&cond);
+    hpxc_mutex_destroy(&mut);
 
     timerclear(&tv);
     gettimeofday(&tv, &tz);

--- a/examples/threads/create_thread.c
+++ b/examples/threads/create_thread.c
@@ -10,8 +10,6 @@
 #include <unistd.h>
 #endif
 
-#include <crtdbg.h>
-
 void* hello_thread(void* p)
 {
     int* n = (int*) p;

--- a/examples/threads/create_thread.c
+++ b/examples/threads/create_thread.c
@@ -10,6 +10,8 @@
 #include <unistd.h>
 #endif
 
+#include <crtdbg.h>
+
 void* hello_thread(void* p)
 {
     int* n = (int*) p;
@@ -17,9 +19,8 @@ void* hello_thread(void* p)
     printf("hello world=%d\n", *n);
     r = (int*) malloc(sizeof(int));
     *r = 2 * (*n);
-    free(p);
     hpxc_thread_exit(r);
-    return r;
+    return NULL;
 }
 
 int main(int argc, char* argv[])
@@ -31,7 +32,9 @@ int main(int argc, char* argv[])
     hpxc_thread_create(&thread, NULL, hello_thread, n);
     hpxc_thread_join(thread, (void**) &r);
     printf("r=%d\n", *r);
+
     free(n);
+    free(r);
 
     return 0;
 }

--- a/src/threads/thread.cpp
+++ b/src/threads/thread.cpp
@@ -308,6 +308,8 @@ int hpxc_thread_attr_getstacksize(
         HPX_ASSERT(false);    // nostack not supported in hpxc
         *stacksize = 0;
         break;
+    default:
+        break;
     }
     return 0;
 }

--- a/src/threads/thread.cpp
+++ b/src/threads/thread.cpp
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
+#include <csetjmp>
 #include <list>
 #include <map>
 
@@ -31,11 +32,6 @@ struct tls_key
     }
 };
 
-struct hpxc_return
-{
-    void* handle = nullptr;
-};
-
 struct thread_handle
 {
     hpx::threads::thread_id_ref_type id;
@@ -48,7 +44,8 @@ struct thread_handle
     int cancel_flags;
     std::map<tls_key*, const void*> thread_local_storage;
     std::vector<hpx::function<void()>> cleanup_functions;
-    hpxc_return retval;
+    void* retval;
+    std::jmp_buf env;
 
     thread_handle()
       : id()
@@ -59,7 +56,7 @@ struct thread_handle
       , promise()
       , future(promise.get_future())
       , cancel_flags(HPXC_THREAD_CANCEL_ENABLE)
-      , retval()
+      , retval(nullptr)
     {
     }
 
@@ -99,6 +96,7 @@ thread_handle* get_thread_data(hpx::threads::thread_id_type id)
 thread_handle* get_thread_data(hpxc_thread_t thread)
 {
     thread_handle* thandle = reinterpret_cast<thread_handle*>(thread.handle);
+    HPX_ASSERT(thandle->magic == MAGIC);
     return thandle;
 }
 
@@ -152,18 +150,15 @@ void wrapper_function(
     // HPX_ASSERT(get_thread_data(thandle->id) == thandle);
     try
     {
-        thandle->retval.handle = thread_function(arguments);
-        thandle->promise.set_value(thandle->retval.handle);
-    }
-    catch (hpxc_return const& ret)
-    {
-        // Handle cancelation
-        thandle->retval.handle = ret.handle;
-        thandle->promise.set_value(ret.handle);
+        if (!setjmp(thandle->env))
+        {
+            thandle->retval = thread_function(arguments);
+        }
+        thandle->promise.set_value(thandle->retval);
     }
     catch (hpx::thread_interrupted const&)
     {
-        thandle->promise.set_value(thandle->retval.handle);
+        thandle->promise.set_value(HPXC_CANCELED);
     }
     catch (...)
     {
@@ -417,8 +412,7 @@ int hpxc_cond_wait(hpxc_cond_t* cond, hpxc_mutex_t* mutex)
     if (cond == nullptr || mutex == nullptr)
         return EINVAL;
 
-    auto* cond_var =
-        reinterpret_cast<hpx::condition_variable*>(cond->handle);
+    auto* cond_var = reinterpret_cast<hpx::condition_variable*>(cond->handle);
     if (cond_var == nullptr)
         return EINVAL;
 
@@ -446,8 +440,7 @@ int hpxc_cond_timedwait(
     if (cond == nullptr || mutex == nullptr || tm == nullptr)
         return EINVAL;
 
-    auto* cond_var =
-        reinterpret_cast<hpx::condition_variable*>(cond->handle);
+    auto* cond_var = reinterpret_cast<hpx::condition_variable*>(cond->handle);
     if (cond_var == nullptr)
         return EINVAL;
 
@@ -490,8 +483,7 @@ int hpxc_cond_broadcast(hpxc_cond_t* cond)
     if (cond == nullptr)
         return EINVAL;
 
-    auto* cond_var =
-        reinterpret_cast<hpx::condition_variable*>(cond->handle);
+    auto* cond_var = reinterpret_cast<hpx::condition_variable*>(cond->handle);
     if (cond_var == nullptr)
         return EINVAL;
 
@@ -512,8 +504,7 @@ int hpxc_cond_signal(hpxc_cond_t* cond)
     if (cond == nullptr)
         return EINVAL;
 
-    auto* cond_var =
-        reinterpret_cast<hpx::condition_variable*>(cond->handle);
+    auto* cond_var = reinterpret_cast<hpx::condition_variable*>(cond->handle);
     if (cond_var == nullptr)
         return EINVAL;
 
@@ -534,8 +525,7 @@ int hpxc_cond_destroy(hpxc_cond_t* cond)
     if (cond == nullptr)
         return EINVAL;
 
-    auto* cond_var =
-        reinterpret_cast<hpx::condition_variable*>(cond->handle);
+    auto* cond_var = reinterpret_cast<hpx::condition_variable*>(cond->handle);
     cond->handle = nullptr;
 
     delete cond_var;
@@ -734,18 +724,13 @@ int hpxc_thread_detach(hpxc_thread_t thread)
 
 ///////////////////////////////////////////////////////////////////////////
 // FIXME: What should I do if not called from an hpx-thread?
-// IMPLEMENT: value_ptr.
 void hpxc_thread_exit(void* value_ptr)
 {
-    // FIXME: is it safe to throw from an extern "C" function?
-    // FIXME: Let's not throw a void* but package it up into a proper
-    //        exception object (derived from hpx::exception)
-    // throw reinterpret_cast<hpxc_return*>(value_ptr);
     auto self_id = hpx::threads::get_self_id();
     thread_handle* self = ::get_thread_data(self_id);
     HPX_ASSERT(self != nullptr);
-    self->retval.handle = value_ptr;
-    hpx::threads::interrupt_thread(self_id);
+    self->retval = value_ptr;
+    std::longjmp(self->env, -1);
 }
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@rtohid please check whether this fixes the issues we were seeing.