### PR TITLE
Add main wrapping through linker (hpxc_wrap)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(HPXC_VERSION
 )
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 cmake_policy(SET CMP0022 NEW)
 
@@ -32,6 +33,9 @@ endif()
 include(HPXC_Utils)
 include(HPXC_SetOutputPaths)
 include(HPXC_SetupHPX)
+
+option(HPXC_WITH_DYNAMIC_HPXC_MAIN "Build hpxc with dynamic main wrap" ON)
+option(HPXC_WITH_SHARED_LIBS "Build hpxc as a shared library" OFF)
 
 add_subdirectory(src)
 

--- a/examples/threads/CMakeLists.txt
+++ b/examples/threads/CMakeLists.txt
@@ -24,11 +24,20 @@ foreach(example_program ${example_programs})
 
   source_group("Source Files" FILES ${sources})
 
+  set(dependencies hpxc)
+  set(link_flags)
+  
+  if (HPXC_WITH_DYNAMIC_HPXC_MAIN)
+    set(dependencies ${dependencies} hpxc_wrap)
+    set(link_flags ${link_flags} -Wl,-wrap=main)
+  endif()
+
   # add example executable
   add_hpx_executable(
     ${example_program}
     SOURCES ${sources} ${${example_program}_FLAGS}
-    DEPENDENCIES hpxc
+    DEPENDENCIES ${dependencies}
+    LINK_FLAGS ${link_flags}
     LANGUAGE C
     FOLDER "Examples/Threads"
   )

--- a/examples/threads/attr_stacksize.c
+++ b/examples/threads/attr_stacksize.c
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 #include <stdio.h>
 
 void* hello_thread(void* p)

--- a/examples/threads/cancel.c
+++ b/examples/threads/cancel.c
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/threads/counter.c
+++ b/examples/threads/counter.c
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/threads/counter2.c
+++ b/examples/threads/counter2.c
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/threads/counter3.c
+++ b/examples/threads/counter3.c
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 #include <stdio.h>
 #include <stdlib.h>
 #if !defined(_MSC_VER)

--- a/examples/threads/counter4.c
+++ b/examples/threads/counter4.c
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/threads/create_thread.c
+++ b/examples/threads/create_thread.c
@@ -4,6 +4,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #if !defined(_MSC_VER)

--- a/examples/threads/fib_naive.c
+++ b/examples/threads/fib_naive.c
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/examples/threads/join_thread.c
+++ b/examples/threads/join_thread.c
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 #include <stdio.h>
 
 void* hello_thread(void* p)

--- a/examples/threads/pthread_compatibility_header.c
+++ b/examples/threads/pthread_compatibility_header.c
@@ -12,9 +12,10 @@
 #include <unistd.h>
 #endif
 
-// this include has to come afte the system include
+// this include has to come after the system include
 // to avoid conflicting types
 #include <hpxc/pthread_compatibility.h>
+#include <hpxc/util/wrap_main.h>
 
 pthread_attr_t attr;
 

--- a/examples/threads/pthread_test.c
+++ b/examples/threads/pthread_test.c
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/pthread_compatibility.h>
+#include <hpxc/util/wrap_main.h>
 #include <stdio.h>
 
 int retval = 0;

--- a/examples/threads/self.c
+++ b/examples/threads/self.c
@@ -4,6 +4,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 #include <stdio.h>
 #include <stdlib.h>
 #if !defined(_MSC_VER)

--- a/examples/threads/thread_local_storage.c
+++ b/examples/threads/thread_local_storage.c
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <hpxc/threads.h>
+#include <hpxc/util/wrap_main.h>
 #include <stdio.h>
 
 hpxc_key_t key;

--- a/hpxc/util/init_hpx.hpp
+++ b/hpxc/util/init_hpx.hpp
@@ -1,26 +1,13 @@
+//  Copyright (c) 2024 Panos Syskakis
 //  Copyright (c) 2022 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if defined(__cplusplus)
-extern "C" {
+#define HPXC_EXTERN_C extern "C"
+#else
+#define HPXC_EXTERN_C
 #endif
 
-int hpxc_user_main(int argc, char** argv);
-
-#if defined(__cplusplus)
-}
-#endif
-
-#if !defined(HPXC_EXPORTS)
-
-// Dispatch differently depending on the number of arguments, such that hpxc_user_main always gets defined with two arguments
-#define HPXC_MAIN0() hpxc_user_main(int _HPXC_UNUSED_ARGC, char** _HPXC_UNUSED_ARGV)
-#define HPXC_MAIN1(...) hpxc_user_main(int _HPXC_UNUSED_ARGC, char** _HPXC_UNUSED_ARGV)
-#define HPXC_MAIN2(...) hpxc_user_main(__VA_ARGS__)
-
-#define HPXC_GET_MAIN_SIGNATURE(_1,_2, NAME,...) NAME
-#define main(...) HPXC_GET_MAIN_SIGNATURE(__VA_ARGS__ __VA_OPT__(,) HPXC_MAIN2, HPXC_MAIN1, HPXC_MAIN0)(__VA_ARGS__)
-
-#endif
+HPXC_EXTERN_C int hpxc_user_main(int argc, char** argv);

--- a/hpxc/util/wrap_main.h
+++ b/hpxc/util/wrap_main.h
@@ -1,0 +1,18 @@
+//  Copyright (c) 2024 Panos Syskakis
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// if HPXC_HAVE_DYNAMIC_HPXC_MAIN is defined, the wrapping is accomplished by linking against hpxc_wrap.a (plus -wrap=main linker flag)
+// else, it is done by the following macro, which renames main to hpxc_user_main
+#if !defined(HPXC_EXPORTS) && !defined(HPXC_HAVE_DYNAMIC_HPXC_MAIN)
+
+// Dispatch differently depending on the number of arguments, such that hpxc_user_main always gets defined with two arguments
+#define HPXC_MAIN0() hpxc_user_main(int _HPXC_UNUSED_ARGC, char** _HPXC_UNUSED_ARGV)
+#define HPXC_MAIN1(...) hpxc_user_main(int _HPXC_UNUSED_ARGC, char** _HPXC_UNUSED_ARGV)
+#define HPXC_MAIN2(...) hpxc_user_main(__VA_ARGS__)
+
+#define HPXC_GET_MAIN_SIGNATURE(_1,_2, NAME,...) NAME
+#define main(...) HPXC_GET_MAIN_SIGNATURE(__VA_ARGS__ __VA_OPT__(,) HPXC_MAIN2, HPXC_MAIN1, HPXC_MAIN0)(__VA_ARGS__)
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Copyright (c) 2024 Panos Syskakis
 # Copyright (c) 2007-2022 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,8 +19,15 @@ set(hpxc_sources src/threads/thread.cpp src/util/gettimeofday.cpp
                  src/util/init_hpx.cpp
 )
 
+# Compile as static or shared library
+if (HPXC_WITH_SHARED_LIBS)
+  set(HPXC_LIBRARY_TYPE SHARED)
+else()
+  set(HPXC_LIBRARY_TYPE STATIC)
+endif()
+
 add_hpx_library(
-  hpxc STATIC
+  hpxc ${HPXC_LIBRARY_TYPE}
   SOURCE_ROOT "${PROJECT_SOURCE_DIR}"
   HEADER_ROOT "${PROJECT_SOURCE_DIR}"
   HEADERS ${hpxc_headers}
@@ -38,4 +46,19 @@ set_target_properties(
              FOLDER "Core"
 )
 
-install(TARGETS hpxc DESTINATION lib)
+set(hpxc_targets hpxc)
+
+if (HPXC_WITH_DYNAMIC_HPXC_MAIN)
+  add_library(hpxc_wrap STATIC ${PROJECT_SOURCE_DIR}/src/util/wrap_main.cpp)
+  target_include_directories(hpxc_wrap PUBLIC ${PROJECT_SOURCE_DIR})
+  target_compile_definitions(hpxc_wrap PUBLIC HPXC_HAVE_DYNAMIC_HPXC_MAIN)
+  target_link_options(hpxc_wrap PUBLIC -Wl,-wrap=main)
+  set(hpxc_targets ${hpxc_targets} hpxc_wrap)
+endif()
+
+install(TARGETS ${hpxc_targets}
+  EXPORT hpxcTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include)

--- a/src/util/init_hpx.cpp
+++ b/src/util/init_hpx.cpp
@@ -1,3 +1,4 @@
+//  Copyright (c) 2024 Panos Syskakis
 //  Copyright (c) 2018-2022 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -20,8 +21,7 @@ int hpxc_user_main_wrapper(int argc, char** argv)
     return retval;
 }
 
-int main(int argc, char** argv)
-{
+HPXC_EXTERN_C int initialize_main(int argc, char** argv){
     // allow for unknown options and inhibit aliasing of short options
     std::vector<std::string> const cfg = {
         "hpx.commandline.allow_unknown=1", "hpx.commandline.aliasing=0"};
@@ -31,3 +31,14 @@ int main(int argc, char** argv)
 
     return hpx::init(&hpxc_user_main_wrapper, argc, argv, init_args);
 }
+
+#if !defined(HPXC_HAVE_DYNAMIC_HPXC_MAIN)
+// In this case, the user must have renamed their main function to 
+// hpxc_user_main, or included wrap_main.hpp which does this for them.
+
+int main(int argc, char** argv)
+{
+    return initialize_main(argc, argv);
+}
+
+#endif 

--- a/src/util/wrap_main.cpp
+++ b/src/util/wrap_main.cpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2024 Panos Syskakis
+//  Copyright (c) 2018-2022 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpxc/util/init_hpx.hpp>
+
+#if defined(HPXC_HAVE_DYNAMIC_HPXC_MAIN)
+
+HPXC_EXTERN_C int __real_main(int argc, char** argv);
+HPXC_EXTERN_C int initialize_main(int argc, char** argv);
+
+HPXC_EXTERN_C int hpxc_user_main(int argc, char** argv){
+    return __real_main(argc, argv);
+}
+
+HPXC_EXTERN_C int __wrap_main(int argc, char* argv[])
+{
+    return initialize_main(argc, argv);
+}
+
+#endif // HPXC_HAVE_DYNAMIC_HPXC_MAIN


### PR DESCRIPTION
Adds the option `HPXC_WITH_DYNAMIC_HPXC_MAIN`. 

When this option is enabled, an additional static library is produced, `hpxc_wrap.a.` 
Linking to `hpxc_wrap.a.`  and using linker option `-wrap=main` enables wrapping the main function of an application such that HPX can be initialized first. 